### PR TITLE
Feat: Memorandum upload management endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,24 @@ This project is brought to you by a dedicated team of developers passionate abou
             </a>
             </td>
             <td align="center">
+            <a href="https://github.com/simacoder">
+                <img src="https://github.com/simacoder.png?size=100" width="100px;" alt="player0-glitch"/>
+                <br />
+                <sub><b>simacoder</b></sub>
+            </a>
+            </td>
+            <td align="center">
             <a href="https://github.com/makamuT">
                 <img src="https://github.com/makamuT.png?size=100" width="100px;" alt="makamuT"/>
                 <br />
                 <sub><b>makamuT</b></sub>
+            </a>
+            </td>
+            <td align="center">
+            <a href="https://github.com/directlypro">
+                <img src="https://github.com/directlypro.png?size=100" width="100px;" alt="0xlebogang"/>
+                <br />
+                <sub><b>directlypro</b></sub>
             </a>
             </td>
             <td align="center">

--- a/services/api/.air.toml
+++ b/services/api/.air.toml
@@ -10,7 +10,7 @@ exclude_unchanged = true
 post_cmd = ["docker stop postgres", "docker stop minio"]
 pre_cmd = [
   "docker run --rm -d --name postgres -e POSTGRES_USER=root -e POSTGRES_PASSWORD=123456 -p 5432:5432 postgres:14-alpine",
-  "docker run --rm -d --name minio -p 9000:9000 quay.io/minio/minio server /data --console-address :9001",
+  "docker run --rm -d --name minio -p 9000:9000 -p 9001:9001 quay.io/minio/minio server /data --console-address :9001",
   "sleep 3",
 ]
 

--- a/services/api/README.md
+++ b/services/api/README.md
@@ -655,6 +655,230 @@ Returns the actual file content with appropriate headers for inline viewing or d
 }
 ```
 
+---
+
+#### Memorandums
+
+##### **POST `/api/v1/memorandums/upload`**
+
+**Request:** Multipart form data with file upload
+
+**Form Fields:**
+- `memorandum_files` (file[]) - Array of memorandum files to upload
+- `exam_id` (string) - The exam ID associated with the memorandums
+
+**Response (200 OK):**
+```json
+{
+  "message": "Memorandums uploaded successfully",
+  "count": 2,
+  "memorandums": [
+    {
+      "id": "cmddih9m9000097hndiy6afpx",
+      "CreatedAt": "2025-07-22T10:30:00Z",
+      "UpdatedAt": "2025-07-22T10:30:00Z",
+      "file_name": "memorandum_001.pdf",
+      "file_url": null,
+      "exam_id": "exam_123",
+      "subject_id": null,
+      "total_marks": null,
+      "processing_status": "uploaded"
+    }
+  ]
+}
+```
+
+**Response (207 Multi-Status):**
+```json
+{
+  "message": "Some memorandums failed to upload",
+  "successful_uploads": 1,
+  "failed_uploads": 1,
+  "errors": [
+    {
+      "filename": "corrupted_file.pdf",
+      "error": "Failed to upload to MinIO storage"
+    }
+  ],
+  "memorandums": [
+    {
+      "id": "cmddih9m9000097hndiy6afpx",
+      "CreatedAt": "2025-07-22T10:30:00Z",
+      "UpdatedAt": "2025-07-22T10:30:00Z",
+      "file_name": "memorandum_001.pdf",
+      "file_url": null,
+      "exam_id": "exam_123",
+      "subject_id": null,
+      "total_marks": null,
+      "processing_status": "uploaded"
+    }
+  ]
+}
+```
+
+#### **GET `/api/v1/memorandums`**
+
+**Response (200 OK):**
+```json
+{
+  "message": "Memorandums retrieved successfully",
+  "memorandums": [
+    {
+      "id": "cmddih9m9000097hndiy6afpx",
+      "CreatedAt": "2025-07-22T10:30:00Z",
+      "UpdatedAt": "2025-07-22T10:30:00Z",
+      "file_name": "memorandum_001.pdf",
+      "file_url": null,
+      "exam_id": "exam_123",
+      "subject_id": "subject_456",
+      "total_marks": 100,
+      "processing_status": "uploaded"
+    }
+  ]
+}
+```
+
+#### **GET `/api/v1/memorandums/{id}`**
+
+**Path Parameters:**
+- `id` (string) - The memorandum's ID in the database
+
+**Response (200 OK):**
+```json
+{
+  "message": "Memorandum retrieved successfully",
+  "memorandum": {
+    "id": "cmddih9m9000097hndiy6afpx",
+    "CreatedAt": "2025-07-22T10:30:00Z",
+    "UpdatedAt": "2025-07-22T10:30:00Z",
+    "file_name": "memorandum_001.pdf",
+    "file_url": null,
+    "exam_id": "exam_123",
+    "subject_id": "subject_456",
+    "total_marks": 100,
+    "processing_status": "uploaded"
+  }
+}
+```
+
+#### **GET `/api/v1/memorandums/serve/{id}`**
+
+**Path Parameters:**
+- `id` (string) - The memorandum's ID in the database
+
+**Response (200 OK):**
+Returns the actual file content with appropriate headers for inline viewing or download.
+
+**Headers:**
+- `Content-Type`: Original file MIME type
+- `Content-Disposition`: `inline; filename="original_filename.pdf"`
+
+#### **PATCH `/api/v1/memorandums/update/{id}`**
+
+**Path Parameters:**
+- `id` (string) - The memorandum's ID in the database
+
+**Request Body:**
+```json
+{
+  "file_name": "string",     // optional
+  "file_url": "string",      // optional
+  "exam_id": "string",       // optional
+  "subject_id": "string",    // optional
+  "total_marks": 100         // optional
+}
+```
+
+**Response (200 OK):**
+```json
+{
+  "message": "Memorandum updated successfully",
+  "memorandum": {
+    "id": "cmddih9m9000097hndiy6afpx",
+    "CreatedAt": "2025-07-22T10:30:00Z",
+    "UpdatedAt": "2025-07-22T10:40:00Z",
+    "file_name": "updated_memorandum.pdf",
+    "file_url": null,
+    "exam_id": "exam_456",
+    "subject_id": "subject_789",
+    "total_marks": 150,
+    "processing_status": "uploaded"
+  }
+}
+```
+
+#### **DELETE `/api/v1/memorandums/delete/{id}`**
+
+**Path Parameters:**
+- `id` (string) - The memorandum's ID in the database
+
+**Response (204 No Content):**
+
+#### Errors
+
+**Error Response (400 Bad Request):**
+```json
+{
+  "message": "Invalid multipart form data",
+  "error": "request Content-Type isn't multipart/form-data"
+}
+```
+
+```json
+{
+  "message": "No memorandum files provided"
+}
+```
+
+```json
+{
+  "message": "exam_id is required"
+}
+```
+
+**Error Response (404 Not Found):**
+```json
+{
+  "message": "Memorandum not found"
+}
+```
+
+**Error Response (500 Internal Server Error):**
+```json
+{
+  "message": "Failed to save memorandum record"
+}
+```
+
+```json
+{
+  "message": "Failed to retrieve memorandums"
+}
+```
+
+```json
+{
+  "message": "Failed to retrieve memorandum file"
+}
+```
+
+```json
+{
+  "message": "Failed to update memorandum"
+}
+```
+
+```json
+{
+  "message": "Failed to delete memorandum"
+}
+```
+
+```json
+{
+  "message": "Failed to delete memorandum file"
+}
+```
 
 ---
 

--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -70,14 +70,14 @@ func main() {
 	subjectService := service.NewSubjectService(subjectRepo)
 	examService := service.NewExamService(examRepo)
 	answerScriptService := service.NewAnswerScriptService(answerScriptRepo, minioClient, cfg)
-	memoranumService := service.NewMemorandumService(memorandumRepo, minioClient, cfg)
+	memorandumService := service.NewMemorandumService(memorandumRepo, minioClient, cfg)
 
 	// Initialize handlers
 	studentHandler := handlers.NewStudentHandler(studentService)
 	subjectHandler := handlers.NewSubjectHandler(subjectService)
 	examHandler := handlers.NewExamHandler(examService)
 	answerScriptHandler := handlers.NewAnswerScriptHandler(answerScriptService)
-	memorandumHandler := handlers.NewMemorandumHandler(memoranumService)
+	memorandumHandler := handlers.NewMemorandumHandler(memorandumService)
 
 	// Create Echo instance
 	e := echo.New()

--- a/services/api/cmd/api/main.go
+++ b/services/api/cmd/api/main.go
@@ -63,18 +63,21 @@ func main() {
 	subjectRepo := repository.NewSubjectRepository(db)
 	examRepo := repository.NewExamRepository(db)
 	answerScriptRepo := repository.NewAnswerScriptRepository(db)
+	memorandumRepo := repository.NewMemorandumRepository(db)
 
 	// Initialize services
 	studentService := service.NewStudentService(studentRepo)
 	subjectService := service.NewSubjectService(subjectRepo)
 	examService := service.NewExamService(examRepo)
 	answerScriptService := service.NewAnswerScriptService(answerScriptRepo, minioClient, cfg)
+	memoranumService := service.NewMemorandumService(memorandumRepo, minioClient, cfg)
 
 	// Initialize handlers
 	studentHandler := handlers.NewStudentHandler(studentService)
 	subjectHandler := handlers.NewSubjectHandler(subjectService)
 	examHandler := handlers.NewExamHandler(examService)
 	answerScriptHandler := handlers.NewAnswerScriptHandler(answerScriptService)
+	memorandumHandler := handlers.NewMemorandumHandler(memoranumService)
 
 	// Create Echo instance
 	e := echo.New()
@@ -119,6 +122,7 @@ func main() {
 		routes.RegisterSubjectRoutes(v1, subjectHandler)
 		routes.RegisterExamRoutes(v1, examHandler)
 		routes.RegisterAnswerScriptRoutes(v1, answerScriptHandler)
+		routes.RegisterMemorandumRoutes(v1, memorandumHandler)
 	}
 
 	go func() {

--- a/services/api/internal/api/handlers/answer_script_handlers.go
+++ b/services/api/internal/api/handlers/answer_script_handlers.go
@@ -59,9 +59,9 @@ func (h *AnswerScriptHandler) UploadScripts(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusCreated, echo.Map{
-		"message":        "Answer scripts uploaded successfully",
-		"count":          len(result.SuccessfulUploads),
-		"answer_scripts": result.SuccessfulUploads,
+		"message":            "Answer scripts uploaded successfully",
+		"successful_uploads": len(result.SuccessfulUploads),
+		"answer_scripts":     result.SuccessfulUploads,
 	})
 }
 

--- a/services/api/internal/api/handlers/answer_script_handlers.go
+++ b/services/api/internal/api/handlers/answer_script_handlers.go
@@ -58,7 +58,7 @@ func (h *AnswerScriptHandler) UploadScripts(c echo.Context) error {
 		})
 	}
 
-	return c.JSON(http.StatusOK, echo.Map{
+	return c.JSON(http.StatusCreated, echo.Map{
 		"message":        "Answer scripts uploaded successfully",
 		"count":          len(result.SuccessfulUploads),
 		"answer_scripts": result.SuccessfulUploads,

--- a/services/api/internal/api/handlers/memorandum_handlers.go
+++ b/services/api/internal/api/handlers/memorandum_handlers.go
@@ -37,7 +37,14 @@ func (h *MemorandumHandler) UploadMemorandum(c echo.Context) error {
 		})
 	}
 
-	examId := form.Value["exam_id"][0]
+	examIdSlice, ok := form.Value["exam_id"]
+	if !ok || len(examIdSlice) == 0 {
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"message": "No exam_id provided",
+		})
+	}
+
+	examId := examIdSlice[0]
 
 	result, err := h.service.UploadFile(file[0], examId, &service.MemorandumUploadResult{})
 	if err != nil {

--- a/services/api/internal/api/handlers/memorandum_handlers.go
+++ b/services/api/internal/api/handlers/memorandum_handlers.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
+	"github.com/smartik/api/internal/service"
+	"gorm.io/gorm"
+)
+
+type MemorandumHandler struct {
+	service *service.MemorandumService
+}
+
+// Creates a new instance of MemorandumHandler
+func NewMemorandumHandler(service *service.MemorandumService) *MemorandumHandler {
+	return &MemorandumHandler{service}
+}
+
+// Handles the upload of a single memorandum file
+func (h *MemorandumHandler) UploadMemorandum(c echo.Context) error {
+	form, err := c.MultipartForm()
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"message": "Invalid multipart form data",
+			"error":   err.Error(),
+		})
+	}
+
+	// Check if files are provided
+	file := form.File["memorandum"]
+	if len(file) == 0 {
+		return c.JSON(http.StatusBadRequest, echo.Map{
+			"message": "No memorandum file provided",
+		})
+	}
+
+	examId := form.Value["exam_id"][0]
+
+	result, err := h.service.UploadFile(file[0], examId, &service.MemorandumUploadResult{})
+	if err != nil {
+		log.Errorf("Upload service error: %v", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"message": "Failed to upload memorandum",
+		})
+	}
+
+	// Return partial content if some uploads failed
+	if len(result.FailedUploads) > 0 {
+		return c.JSON(http.StatusPartialContent, echo.Map{
+			"message":            "Some memorandums failed to upload",
+			"successful_uploads": len(result.SuccessfulUploads),
+			"failed_uploads":     len(result.FailedUploads),
+			"errors":             result.FailedUploads,
+			"memorandums":        result.SuccessfulUploads,
+		})
+	}
+
+	return c.JSON(http.StatusOK, echo.Map{
+		"message":            "Memorandum uploaded successfully",
+		"successful_uploads": len(result.SuccessfulUploads),
+		"memorandums":        result.SuccessfulUploads,
+	})
+}
+
+// Retrieves all memorandums
+func (h *MemorandumHandler) GetAllMemorandums(c echo.Context) error {
+	memorandums, err := h.service.GetAll()
+	if err != nil {
+		log.Errorf("Failed to get all memorandums: %v", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"message": "Failed to retrieve memorandums",
+		})
+	}
+
+	return c.JSON(http.StatusOK, echo.Map{
+		"message":     "Memorandums retrieved successfully",
+		"memorandums": memorandums,
+	})
+}
+
+// Retrieves a specific memorandum by ID
+func (h *MemorandumHandler) GetMemorandumById(c echo.Context) error {
+	id := c.Param("id")
+	memorandum, err := h.service.GetById(id)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return c.JSON(http.StatusNotFound, echo.Map{
+				"message": "Memorandum not found",
+			})
+		}
+
+		log.Errorf("Failed to get memorandum by ID: %v", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"message": "Failed to retrieve memorandum",
+		})
+	}
+
+	return c.JSON(http.StatusOK, echo.Map{
+		"message":    "Memorandum retrieved successfully",
+		"memorandum": memorandum,
+	})
+}
+
+// Handlets the serving of a memorandum file
+func (h *MemorandumHandler) ServeMemorandumFile(c echo.Context) error {
+	id := c.Param("id")
+
+	// Get the file stream for the memorandum
+	fileStream, err := h.service.GetFileStream(id)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return c.JSON(http.StatusNotFound, echo.Map{
+				"message": "Memorandum file not found",
+			})
+		}
+		log.Errorf("Failed to get file stream: %v", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"message": "Failed to retrieve memorandum file",
+		})
+	}
+	defer fileStream.Content.Close()
+
+	// Set the response headers for file download
+	c.Response().Header().Set(echo.HeaderContentType, fileStream.ContentType)
+	c.Response().Header().Set(echo.HeaderContentLength, fmt.Sprintf("%d", fileStream.Size))
+	c.Response().Header().Set(echo.HeaderContentDisposition, fmt.Sprintf("inline; filename=\"%s\"", fileStream.Filename))
+
+	return c.Stream(http.StatusOK, fileStream.ContentType, fileStream.Content)
+}
+
+// Deletes a memorandum by ID
+func (h *MemorandumHandler) DeleteMemorandum(c echo.Context) error {
+	id := c.Param("id")
+	if err := h.service.Delete(id); err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return c.JSON(http.StatusNotFound, echo.Map{
+				"message": "Memorandum not found",
+			})
+		}
+
+		log.Errorf("Failed to delete memorandum: %v", err)
+		return c.JSON(http.StatusInternalServerError, echo.Map{
+			"message": "Failed to delete memorandum",
+		})
+	}
+
+	return c.JSON(http.StatusOK, echo.Map{
+		"message": "Memorandum deleted successfully",
+	})
+}

--- a/services/api/internal/api/handlers/memorandum_handlers.go
+++ b/services/api/internal/api/handlers/memorandum_handlers.go
@@ -65,7 +65,7 @@ func (h *MemorandumHandler) UploadMemorandum(c echo.Context) error {
 		})
 	}
 
-	return c.JSON(http.StatusOK, echo.Map{
+	return c.JSON(http.StatusCreated, echo.Map{
 		"message":            "Memorandum uploaded successfully",
 		"successful_uploads": len(result.SuccessfulUploads),
 		"memorandums":        result.SuccessfulUploads,

--- a/services/api/internal/api/handlers/memorandum_handlers.go
+++ b/services/api/internal/api/handlers/memorandum_handlers.go
@@ -111,7 +111,7 @@ func (h *MemorandumHandler) GetMemorandumById(c echo.Context) error {
 	})
 }
 
-// Handlets the serving of a memorandum file
+// Handles the serving of a memorandum file
 func (h *MemorandumHandler) ServeMemorandumFile(c echo.Context) error {
 	id := c.Param("id")
 

--- a/services/api/internal/api/routes/memorandum_routes.go
+++ b/services/api/internal/api/routes/memorandum_routes.go
@@ -1,0 +1,17 @@
+package routes
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/smartik/api/internal/api/handlers"
+)
+
+func RegisterMemorandumRoutes(e *echo.Group, handlers *handlers.MemorandumHandler) {
+	memorandums := e.Group("/memorandums")
+
+	memorandums.POST("/upload", handlers.UploadMemorandum).Name = "upload_memorandum"
+	memorandums.GET("", handlers.GetAllMemorandums).Name = "get_all_memorandums"
+	memorandums.GET("/:id", handlers.GetMemorandumById).Name = "get_memorandum_by_id"
+	memorandums.GET("/serve/:id", handlers.ServeMemorandumFile).Name = "serve_memorandum_file"
+	// memorandums.PATCH("/update/:id", handlers.kk).Name = "update_memorandum"
+	memorandums.DELETE("/delete/:id", handlers.DeleteMemorandum).Name = "delete_memorandum"
+}

--- a/services/api/internal/api/routes/memorandum_routes.go
+++ b/services/api/internal/api/routes/memorandum_routes.go
@@ -12,6 +12,6 @@ func RegisterMemorandumRoutes(e *echo.Group, handlers *handlers.MemorandumHandle
 	memorandums.GET("", handlers.GetAllMemorandums).Name = "get_all_memorandums"
 	memorandums.GET("/:id", handlers.GetMemorandumById).Name = "get_memorandum_by_id"
 	memorandums.GET("/serve/:id", handlers.ServeMemorandumFile).Name = "serve_memorandum_file"
-	// memorandums.PATCH("/update/:id", handlers.kk).Name = "update_memorandum"
+	// TODO: Implement update functionality
 	memorandums.DELETE("/delete/:id", handlers.DeleteMemorandum).Name = "delete_memorandum"
 }

--- a/services/api/internal/models/memorandum.go
+++ b/services/api/internal/models/memorandum.go
@@ -1,0 +1,8 @@
+package models
+
+type Memorandum struct {
+	BaseModel
+	FileName string `json:"file_name" gorm:"type:varchar(255);not null" validate:"omitempty"`
+	ExamId   string `json:"exam_id" gorm:"type:varchar(25);not null" validate:"required"`
+	Exam     *Exam  `json:"exam,omitempty" gorm:"foreignKey:ExamId;references:Id;constraint:OnDelete:CASCADE"`
+}

--- a/services/api/internal/models/utils.go
+++ b/services/api/internal/models/utils.go
@@ -6,5 +6,6 @@ func GetAllModels() []interface{} {
 		&Subject{},
 		&Exam{},
 		&AnswerScript{},
+		&Memorandum{},
 	}
 }

--- a/services/api/internal/repository/memorandum_repo.go
+++ b/services/api/internal/repository/memorandum_repo.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"github.com/smartik/api/internal/models"
+	"gorm.io/gorm"
+)
+
+type MemorandumRepository struct {
+	db *gorm.DB
+}
+
+// Creates a new instance of MemorandumRepository
+func NewMemorandumRepository(db *gorm.DB) *MemorandumRepository {
+	return &MemorandumRepository{db}
+}
+
+// Creates a new memorandum record in the database
+func (r *MemorandumRepository) Create(memorandum *models.Memorandum) error {
+	return r.db.Create(memorandum).Error
+}
+
+// Retrieves all memorandums from the database
+func (r *MemorandumRepository) GetAll() (*[]models.Memorandum, error) {
+	var memorandums []models.Memorandum
+	if err := r.db.Find(&memorandums).Error; err != nil {
+		return nil, err
+	}
+	return &memorandums, nil
+}
+
+// Retrieves a specific memorandum by its ID
+func (r *MemorandumRepository) GetById(id string) (*models.Memorandum, error) {
+	var memorandum models.Memorandum
+	if err := r.db.Where("id = ?", id).First(&memorandum).Error; err != nil {
+		return nil, err
+	}
+	return &memorandum, nil
+}
+
+// Updates an existing memorandum record
+func (r *MemorandumRepository) Update(id string, data *models.Memorandum) (*models.Memorandum, error) {
+	memorandum, err := r.GetById(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.db.Model(&memorandum).Updates(data).Error; err != nil {
+		return nil, err
+	}
+	return memorandum, nil
+}
+
+// Deletes a memorandum from the database
+func (r *MemorandumRepository) Delete(id string) error {
+	memorandum, err := r.GetById(id)
+	if err != nil {
+		return err
+	}
+	return r.db.Delete(memorandum).Error
+}

--- a/services/api/internal/service/answer_script_service.go
+++ b/services/api/internal/service/answer_script_service.go
@@ -51,7 +51,7 @@ func (s *AnswerScriptService) UploadFiles(files []*multipart.FileHeader) (*Answe
 	// Process each file individually
 	for _, file := range files {
 		if err := s.uploadSingleFile(file, result); err != nil {
-			continue // error handled by in `uploadSingleFile
+			continue // error handled in `uploadSingleFile`
 		}
 	}
 
@@ -153,11 +153,7 @@ func (s *AnswerScriptService) Delete(id string) error {
 	}
 
 	// Delete from database
-	if err := s.repo.Delete(id); err != nil {
-		return err
-	}
-
-	return nil
+	return s.repo.Delete(id)
 }
 
 // Retrieves a file stream from storage for serving files

--- a/services/api/internal/service/file_upload.go
+++ b/services/api/internal/service/file_upload.go
@@ -1,0 +1,19 @@
+package service
+
+import "io"
+
+type UploadResult struct {
+	FailedUploads []FileUploadError `json:"failed_uploads"`
+}
+
+type FileUploadError struct {
+	Filename string
+	Error    string
+}
+
+type FileStreamResult struct {
+	Content     io.ReadCloser
+	ContentType string
+	Filename    string
+	Size        int64
+}

--- a/services/api/internal/service/file_upload.go
+++ b/services/api/internal/service/file_upload.go
@@ -17,3 +17,10 @@ type FileStreamResult struct {
 	Filename    string
 	Size        int64
 }
+
+func (u *UploadResult) addUploadError(filename, errorMsg string) {
+	u.FailedUploads = append(u.FailedUploads, FileUploadError{
+		Filename: filename,
+		Error:    errorMsg,
+	})
+}

--- a/services/api/internal/service/memorandum_service.go
+++ b/services/api/internal/service/memorandum_service.go
@@ -1,0 +1,156 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+
+	"github.com/labstack/gommon/log"
+	minio "github.com/minio/minio-go/v7"
+	"github.com/smartik/api/internal/config"
+	"github.com/smartik/api/internal/models"
+	"github.com/smartik/api/internal/repository"
+)
+
+type MemorandumService struct {
+	repo        *repository.MemorandumRepository
+	minioClient *minio.Client
+	cfg         *config.Env
+}
+
+type MemorandumUploadResult struct {
+	UploadResult
+	SuccessfulUploads []models.Memorandum `json:"successful_uploads"`
+}
+
+// Creates a new instance of MemorandumService
+func NewMemorandumService(
+	repo *repository.MemorandumRepository,
+	minioClient *minio.Client,
+	cfg *config.Env,
+) *MemorandumService {
+	return &MemorandumService{repo, minioClient, cfg}
+}
+
+// Handles the upload of a single memorandum file
+func (s *MemorandumService) UploadFile(file *multipart.FileHeader, examId string, result *MemorandumUploadResult) (*MemorandumUploadResult, error) {
+	src, err := file.Open()
+	if err != nil {
+		result.FailedUploads = append(result.FailedUploads, FileUploadError{
+			Filename: file.Filename,
+			Error:    "Failed to open file: " + err.Error(),
+		})
+		return nil, err
+	}
+	defer src.Close()
+
+	// Upload the file to MinIO
+	if err := s.uploadToStorage(file.Filename, src, file.Size, file.Header.Get("Content-Type")); err != nil {
+		result.FailedUploads = append(result.FailedUploads, FileUploadError{
+			Filename: file.Filename,
+			Error:    "Failed to upload file to storage: " + err.Error(),
+		})
+	}
+
+	// Create database record
+	memorandum := &models.Memorandum{
+		FileName: file.Filename,
+		ExamId:   examId,
+	}
+
+	if err := s.repo.Create(memorandum); err != nil {
+		if deleteErr := s.repo.Delete(file.Filename); deleteErr != nil {
+			log.Errorf("Failed to delete memorandum record after upload error: %v", deleteErr)
+		}
+
+		result.FailedUploads = append(result.FailedUploads, FileUploadError{
+			Filename: file.Filename,
+		})
+	}
+
+	result.SuccessfulUploads = append(result.SuccessfulUploads, *memorandum)
+	return result, nil
+}
+
+// Retrieves a file stream for serving the memorandum file
+func (s *MemorandumService) GetFileStream(id string) (*FileStreamResult, error) {
+	memorandum, err := s.repo.GetById(id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the file from MinIO storage
+	object, err := s.minioClient.GetObject(
+		context.Background(),
+		s.cfg.MinioStorageBucket,
+		memorandum.FileName,
+		minio.GetObjectOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file from storage: %v", err)
+	}
+
+	// Get file metadata
+	objectInfo, err := object.Stat()
+	if err != nil {
+		object.Close()
+		return nil, fmt.Errorf("failed to get file info: %v", err)
+	}
+
+	return &FileStreamResult{
+		Content:     object,
+		ContentType: objectInfo.ContentType,
+		Filename:    memorandum.FileName,
+		Size:        objectInfo.Size,
+	}, nil
+}
+
+// Retrieves all memorandums from the database
+func (s *MemorandumService) GetAll() (*[]models.Memorandum, error) {
+	return s.repo.GetAll()
+}
+
+// Retrieves a specific memorandum by its ID
+func (s *MemorandumService) GetById(id string) (*models.Memorandum, error) {
+	return s.repo.GetById(id)
+}
+
+// Removes a memorandum from the database and MinIO storage
+func (s *MemorandumService) Delete(id string) error {
+	memorandum, err := s.repo.GetById(id)
+	if err != nil {
+		return err
+	}
+
+	// Delete from MinIO storage
+	if err := s.deleteFromStorage(memorandum.FileName); err != nil {
+		return err
+	}
+
+	// Delete from database
+	return s.repo.Delete(id)
+}
+
+// Handles the actual file upload to MinIO
+func (s *MemorandumService) uploadToStorage(filename string, src io.Reader, size int64, contentType string) error {
+	_, err := s.minioClient.PutObject(
+		context.Background(),
+		s.cfg.MinioStorageBucket,
+		filename,
+		src,
+		size,
+		minio.PutObjectOptions{ContentType: contentType},
+	)
+	return err
+}
+
+// Removes a file from MinIO storage
+func (s *MemorandumService) deleteFromStorage(filename string) error {
+	return s.minioClient.RemoveObject(
+		context.Background(),
+		s.cfg.MinioStorageBucket,
+		filename,
+		minio.RemoveObjectOptions{},
+	)
+}

--- a/services/api/internal/service/memorandum_service.go
+++ b/services/api/internal/service/memorandum_service.go
@@ -57,7 +57,7 @@ func (s *MemorandumService) UploadFile(file *multipart.FileHeader, examId string
 	}
 
 	if err := s.repo.Create(memorandum); err != nil {
-		if deleteErr := s.repo.Delete(file.Filename); deleteErr != nil {
+		if deleteErr := s.repo.Delete(memorandum.Id); deleteErr != nil {
 			log.Errorf("Failed to delete memorandum record after upload error: %v", deleteErr)
 		}
 		result.addUploadError(file.Filename, "Failed to open file: "+err.Error())


### PR DESCRIPTION
This pull request introduces a new feature for handling "memorandums" in the API, along with some general improvements and fixes. The most significant changes include adding support for memorandum-related operations (upload, retrieval, and deletion), refactoring file upload logic for better reusability, and updating configurations and documentation.

### Memorandum Feature Implementation:
* **New Memorandum Model and Repository**:
  - Added a `Memorandum` model to represent memorandum records in the database (`services/api/internal/models/memorandum.go`, [services/api/internal/models/memorandum.goR1-R8](diffhunk://#diff-8eb3cb3754ffed8803880042cbe6812602cb0c62d604d1701f9231bf5b7fd07dR1-R8)).
  - Created a `MemorandumRepository` for database operations like create, retrieve, update, and delete (`services/api/internal/repository/memorandum_repo.go`, [services/api/internal/repository/memorandum_repo.goR1-R60](diffhunk://#diff-1ca6bf5babbd54de0f212028f96e174dd7def3c0369f03de660ec16ca6627f43R1-R60)).

* **Memorandum Service and Handlers**:
  - Implemented a `MemorandumService` to handle business logic for memorandums, including file upload and retrieval (`services/api/internal/service/file_upload.go`, [services/api/internal/service/file_upload.goR1-R26](diffhunk://#diff-0523f5b8bdd14c0f0718486f4226956bffcc9017f3eb9b7f72bb90910ffa4b10R1-R26)).
  - Added `MemorandumHandler` for API endpoints to manage memorandums (`services/api/internal/api/handlers/memorandum_handlers.go`, [services/api/internal/api/handlers/memorandum_handlers.goR1-R153](diffhunk://#diff-57357464c56597320329d4d2da466a460f38148cf1c13a08ff3ac5411188c5e5R1-R153)).

* **New API Routes**:
  - Registered new routes for memorandum operations such as upload, retrieval, and deletion (`services/api/internal/api/routes/memorandum_routes.go`, [services/api/internal/api/routes/memorandum_routes.goR1-R17](diffhunk://#diff-8a0fbf46a68595f6330e893b4346e795b1b9d83839d5c261b6bd49e3d398bcecR1-R17)).
  - Integrated the routes into the main API initialization (`services/api/cmd/api/main.go`, [[1]](diffhunk://#diff-2599d292701485620319dac239d41974d6f93252482b989027b0a27c8244c1c8R66-R80) [[2]](diffhunk://#diff-2599d292701485620319dac239d41974d6f93252482b989027b0a27c8244c1c8R125).

### Refactoring and Improvements:
* **Reusable File Upload Logic**:
  - Extracted common file upload and error-handling logic into a shared `UploadResult` struct (`services/api/internal/service/file_upload.go`, [services/api/internal/service/file_upload.goR1-R26](diffhunk://#diff-0523f5b8bdd14c0f0718486f4226956bffcc9017f3eb9b7f72bb90910ffa4b10R1-R26)).
  - Updated `AnswerScriptService` to use the new reusable logic, improving consistency and reducing duplication (`services/api/internal/service/answer_script_service.go`, [[1]](diffhunk://#diff-354d5fbb0dc1b9fbe5c8f188c44f2ea286bc8415eaeb7a353912f48980f8e75fL23-L40) [[2]](diffhunk://#diff-354d5fbb0dc1b9fbe5c8f188c44f2ea286bc8415eaeb7a353912f48980f8e75fL58-R62).

* **Response Code Adjustment**:
  - Changed the HTTP status code for successful answer script uploads from `200 OK` to `201 Created` for better semantic accuracy (`services/api/internal/api/handlers/answer_script_handlers.go`, [services/api/internal/api/handlers/answer_script_handlers.goL61-R63](diffhunk://#diff-09805ea29d67857d49996b56486f41d3e3eb08a4c855bb2462f11dbce25d8dbbL61-R63)).

### Configuration and Documentation Updates:
* **Configuration Changes**:
  - Adjusted the MinIO container's port binding in `.air.toml` to expose the console on a separate port (`services/api/.air.toml`, [services/api/.air.tomlL13-R13](diffhunk://#diff-f07f778c02714525349c1d1770ce771e13a103c0576154f0d293e9d04fe28d5aL13-R13)).

* **Documentation Enhancements**:
  - Expanded the API documentation to include details about memorandum endpoints, request/response formats, and error handling (`services/api/README.md`, [services/api/README.mdR658-R881](diffhunk://#diff-3741204d1cad608d22447ac2a484a4494b8e5fb2cfe1799bc1195504f10b0795R658-R881)).
  - Updated the project `README.md` to include new contributors (`README.md`, [README.mdR38-R58](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R38-R58)).